### PR TITLE
graphdb repository migrations

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -89,6 +89,7 @@ services:
       - docker_example_network
 
   createbuckets:
+    # Creates the buckets on minio for the harvester to move assets into
     image: minio/mc
     depends_on:
       - minio
@@ -100,6 +101,23 @@ services:
       /usr/bin/mc anonymous set public myminio/gleanerbucket;
       sleep infinity;
        "
+    networks:
+      - docker_example_network
+    
+  createrepositories:
+    # Applies migrations aka "repositories" after the database is created
+    image: alpine/curl
+    depends_on:
+      - graphdb
+    # Apply the local config files into the graphdb. We sleep 5 since even after the service is up, the graphdb is not fully ready    
+    entrypoint: > 
+     /bin/sh -c "
+     sleep 5;
+     curl -X POST http://graphdb:7200/rest/repositories -H 'Content-Type: multipart/form-data' -F 'config=@templates/iow-config.ttl'; 
+     curl -X POST http://graphdb:7200/rest/repositories -H 'Content-Type: multipart/form-data' -F 'config=@templates/iowprov-config.ttl'; 
+     sleep infinity"
+    volumes: 
+      - ./templates:/templates
     networks:
       - docker_example_network
 

--- a/templates/iow-config.ttl
+++ b/templates/iow-config.ttl
@@ -1,0 +1,49 @@
+#
+# RDF4J configuration template for a GraphDB repository
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix graphdb: <http://www.ontotext.com/config/graphdb#>.
+
+[] a rep:Repository ;
+    rep:repositoryID "iow" ;
+    rdfs:label "iow repository" ;
+    rep:repositoryImpl [
+        rep:repositoryType "graphdb:SailRepository" ;
+        sr:sailImpl [
+            sail:sailType "graphdb:Sail" ;
+
+            graphdb:read-only "false" ;
+
+            # Inference and Validation
+            graphdb:ruleset "rdfsplus-optimized" ;
+            graphdb:disable-sameAs "true" ;
+            graphdb:check-for-inconsistencies "false" ;
+
+            # Indexing
+            graphdb:entity-id-size "32" ;
+            graphdb:enable-context-index "false" ;
+            graphdb:enablePredicateList "true" ;
+            graphdb:enable-fts-index "false" ;
+            graphdb:fts-indexes ("default" "iri") ;
+            graphdb:fts-string-literals-index "default" ;
+            graphdb:fts-iris-index "none" ;
+
+            # Queries and Updates
+            graphdb:query-timeout "0" ;
+            graphdb:throw-QueryEvaluationException-on-timeout "false" ;
+            graphdb:query-limit-results "0" ;
+
+            # Settable in the file but otherwise hidden in the UI and in the RDF4J console
+            graphdb:base-URL "http://example.org/owlim#" ;
+            graphdb:defaultNS "" ;
+            graphdb:imports "" ;
+            graphdb:repository-type "file-repository" ;
+            graphdb:storage-folder "storage" ;
+            graphdb:entity-index-size "10000000" ;
+            graphdb:in-memory-literal-properties "true" ;
+            graphdb:enable-literal-index "true" ;
+        ]
+    ].

--- a/templates/iowprov-config.ttl
+++ b/templates/iowprov-config.ttl
@@ -1,0 +1,49 @@
+#
+# RDF4J configuration template for a GraphDB repository
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix graphdb: <http://www.ontotext.com/config/graphdb#>.
+
+[] a rep:Repository ;
+    rep:repositoryID "iowprov" ;
+    rdfs:label "iowprov repository" ;
+    rep:repositoryImpl [
+        rep:repositoryType "graphdb:SailRepository" ;
+        sr:sailImpl [
+            sail:sailType "graphdb:Sail" ;
+
+            graphdb:read-only "false" ;
+
+            # Inference and Validation
+            graphdb:ruleset "rdfsplus-optimized" ;
+            graphdb:disable-sameAs "true" ;
+            graphdb:check-for-inconsistencies "false" ;
+
+            # Indexing
+            graphdb:entity-id-size "32" ;
+            graphdb:enable-context-index "false" ;
+            graphdb:enablePredicateList "true" ;
+            graphdb:enable-fts-index "false" ;
+            graphdb:fts-indexes ("default" "iri") ;
+            graphdb:fts-string-literals-index "default" ;
+            graphdb:fts-iris-index "none" ;
+
+            # Queries and Updates
+            graphdb:query-timeout "0" ;
+            graphdb:throw-QueryEvaluationException-on-timeout "false" ;
+            graphdb:query-limit-results "0" ;
+
+            # Settable in the file but otherwise hidden in the UI and in the RDF4J console
+            graphdb:base-URL "http://example.org/owlim#" ;
+            graphdb:defaultNS "" ;
+            graphdb:imports "" ;
+            graphdb:repository-type "file-repository" ;
+            graphdb:storage-folder "storage" ;
+            graphdb:entity-index-size "10000000" ;
+            graphdb:in-memory-literal-properties "true" ;
+            graphdb:enable-literal-index "true" ;
+        ]
+    ].


### PR DESCRIPTION
Adds the necessary migrations for graphdb to have the repositories added on startup. Images here show a successful run for the hu02 assets

Just wanted to confirm that these config settings are reasonable. Wasn't sure if there are specific other settings we need or you added in the GUI. I am using a default example config. 

![image](https://github.com/user-attachments/assets/e9b7e4a2-6990-4328-ac47-57ab57a0c8c9)
![image](https://github.com/user-attachments/assets/7b6a3d3c-32d9-4910-951e-044cef7f99a4)
![image](https://github.com/user-attachments/assets/895c2f1c-6e43-4d07-917f-d0b085abefa7)
![image](https://github.com/user-attachments/assets/2da8da71-e5b1-4c9c-a630-82342d221e87)
