### PR TITLE
add last missing env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 GLEANERIO_WORKSPACE_CONFIG_PATH=./workspace.yaml
 DEBUG=False
 GLEANERIO_HEADLESS_NETWORK=headless_gleanerio
+
+GLEANERIO_CONFIG_VOLUME=gleanerio_config
 GLEANERIO_GLEANER_CONFIG_PATH=./build/gleanerconfig.yaml
 GLEANERIO_NABU_CONFIG_PATH=./nabuconfig.example.yaml
 


### PR DESCRIPTION
Believe we missed one last env var.

At the moment this env isn't needed for dagster / gleaner / nabu, it is just used for making the docker volume that was previously used for managing configs. Assuming we want to keep Docker swarm, we will need to keep this here for the time being. 

Once I have a better idea on how we want to do orchestration I think we can take another look at this and how we are passing around configs.