### PR TITLE
speed up by detaching in ci/cd

### DIFF
--- a/main.py
+++ b/main.py
@@ -99,9 +99,11 @@ def up(local: bool, debug: bool):
     else:
         compose_args = "-c ./Docker/docker-compose-user-code.yaml -c ./Docker/docker-compose-separated-dagster.yaml"
 
-    run_subprocess(
-        f"docker stack deploy {compose_args} geoconnex_crawler --detach=false"
-    )
+    # if we are in ci/cd we want to run the stack in the background so we don't wait for convergence and validating all the containers after they are spun up
+    detach_for_speedup = not sys.stdin.isatty()
+    docker_stack_cmd = f"docker stack deploy {compose_args} geoconnex_crawler --detach={detach_for_speedup}"
+    print(f"Deploying infrastructure with command: '{docker_stack_cmd}'")
+    run_subprocess(docker_stack_cmd)
 
 
 def refresh():


### PR DESCRIPTION
Docker swarm has a slow 5 second check for each service in the stack. This is good in production but it is overkill for ci/cd since the pipeline will fail if it s wrong anyways. So for the sake of speed I think it makes sense to try and skip these checks