### PR TITLE
Fix Dagster Schedule

### DIFF
--- a/userCode/main.py
+++ b/userCode/main.py
@@ -17,6 +17,7 @@ from dagster import (
     DefaultSensorStatus,
     Definitions,
     OpExecutionContext,
+    ScheduleEvaluationContext,
     asset,
     asset_check,
     define_asset_job,
@@ -589,10 +590,10 @@ harvest_job = define_asset_job(
     cron_schedule="@weekly",
     job=harvest_job,
     default_status=DefaultScheduleStatus.STOPPED
-    if RUNNING_AS_TEST_OR_DEV
+    if RUNNING_AS_TEST_OR_DEV()
     else DefaultScheduleStatus.RUNNING,
 )
-def crawl_entire_graph_schedule(context):
+def crawl_entire_graph_schedule(context: ScheduleEvaluationContext):
     get_dagster_logger().info("Schedule triggered.")
 
     result = materialize([gleaner_config], instance=context.instance)
@@ -611,7 +612,7 @@ def crawl_entire_graph_schedule(context):
                 tags={"run_type": "harvest_weekly"},
             )
     else:
-        get_dagster_logger().warning("No partition keys found.")
+        RuntimeError("No partition keys found.")
 
 
 # expose all the code needed for our dagster repo

--- a/userCode/main.py
+++ b/userCode/main.py
@@ -24,7 +24,7 @@ from dagster import (
     load_asset_checks_from_current_module,
     load_assets_from_current_module,
     schedule,
-    materialize
+    materialize,
 )
 import docker
 import dagster_slack
@@ -588,7 +588,9 @@ harvest_job = define_asset_job(
 @schedule(
     cron_schedule="@weekly",
     job=harvest_job,
-    default_status=DefaultScheduleStatus.STOPPED if RUNNING_AS_TEST_OR_DEV else DefaultScheduleStatus.RUNNING,
+    default_status=DefaultScheduleStatus.STOPPED
+    if RUNNING_AS_TEST_OR_DEV
+    else DefaultScheduleStatus.RUNNING,
 )
 def crawl_entire_graph_schedule(context):
     get_dagster_logger().info("Schedule triggered.")
@@ -599,14 +601,14 @@ def crawl_entire_graph_schedule(context):
 
     partition_keys = context.instance.get_dynamic_partitions("sources_partitions_def")
     get_dagster_logger().info(f"Partition keys: {partition_keys}")
-    
+
     if partition_keys:
         for partition_key in partition_keys:
             yield RunRequest(
                 job_name="harvest_source",
                 run_key="havest_weekly",
                 partition_key=partition_key,
-                tags={"run_type": "harvest_weekly"}
+                tags={"run_type": "harvest_weekly"},
             )
     else:
         get_dagster_logger().warning("No partition keys found.")

--- a/userCode/main.py
+++ b/userCode/main.py
@@ -24,6 +24,7 @@ from dagster import (
     load_asset_checks_from_current_module,
     load_assets_from_current_module,
     schedule,
+    materialize
 )
 import docker
 import dagster_slack
@@ -585,13 +586,30 @@ harvest_job = define_asset_job(
 
 
 @schedule(
-    cron_schedule="@daily",
+    cron_schedule="@weekly",
     job=harvest_job,
     default_status=DefaultScheduleStatus.STOPPED,
 )
-def crawl_entire_graph_schedule():
-    for partition_key in sources_partitions_def.get_partition_keys():
-        yield RunRequest(partition_key=partition_key)
+def crawl_entire_graph_schedule(context):
+    get_dagster_logger().info("Schedule triggered.")
+
+    result = materialize([gleaner_config], instance=context.instance)
+    if not result.success:
+        raise Exception(f"Failed to materialize gleaner_config!: {result}")
+
+    partition_keys = context.instance.get_dynamic_partitions("sources_partitions_def")
+    get_dagster_logger().info(f"Partition keys: {partition_keys}")
+    
+    if partition_keys:
+        for partition_key in partition_keys:
+            yield RunRequest(
+                job_name="harvest_source",
+                run_key="havest_weekly",
+                partition_key=partition_key,
+                tags={"run_type": "harvest_weekly"}
+            )
+    else:
+        get_dagster_logger().warning("No partition keys found.")
 
 
 # expose all the code needed for our dagster repo

--- a/userCode/main.py
+++ b/userCode/main.py
@@ -588,7 +588,7 @@ harvest_job = define_asset_job(
 @schedule(
     cron_schedule="@weekly",
     job=harvest_job,
-    default_status=DefaultScheduleStatus.STOPPED,
+    default_status=DefaultScheduleStatus.STOPPED if RUNNING_AS_TEST_OR_DEV else DefaultScheduleStatus.RUNNING,
 )
 def crawl_entire_graph_schedule(context):
     get_dagster_logger().info("Schedule triggered.")


### PR DESCRIPTION
This PR ensures the schedule works on production instances of scheduler. It ensures that the gleaner configuration has been materialized to load all partitions and then submits a run request for each partition. Note it does not quite seem possible to launch all of the runs as a single backfill, or atleast I did not feel particularly inclined to go down the rabbit hole of https://docs.dagster.io/guides/build/partitions-and-backfills/backfilling-data#launching-single-run-backfills-using-backfill-policies-experimental