### PR TITLE
`addlicense` precommit hook

### DIFF
--- a/.github/workflows/build_prod_test.yml
+++ b/.github/workflows/build_prod_test.yml
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 # NOTE: this only tests building, there is no good way to test
 # runtime functionality in prod without using pytest
 name: Test Prod Build

--- a/.github/workflows/build_prod_test.yml
+++ b/.github/workflows/build_prod_test.yml
@@ -1,0 +1,28 @@
+# NOTE: this only tests building, there is no good way to test
+# runtime functionality in prod without using pytest
+name: Test Prod Build
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-build-prod:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v2
+
+      - name: Launch Docker Compose
+        run: python3 main.py prod --detach
+
+      - name: Debug Docker Containers
+        shell: bash
+        run: docker ps -a

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 name: E2E Test Pipeline
 
 on:

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 name: Pyright Type Checks
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,6 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: destroyed-symlinks
       - id: detect-private-key
-      - id: end-of-file-fixer
-        exclude_types: [svg]
-        verbose: true
       - id: fix-byte-order-marker
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,8 +49,8 @@ repos:
       # Update the uv lockfile
       - id: uv-lock
       - id: uv-export
-  - repo: https://github.com/XuehaiPan/addlicense
-    rev: "0a8669"
+  - repo: https://github.com/google/addlicense
+    rev: "55a521bf81c24480094950caa3566548fa63875e"
     hooks:
       - id: addlicense
         args: ["-s=only", -l, "MIT", -c, "Lincoln Institute of Land Policy"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 minimum_pre_commit_version: "2.9.0"
 ci:
   autoupdate_schedule: monthly
@@ -49,7 +52,7 @@ repos:
       - id: uv-lock
       - id: uv-export
   - repo: https://github.com/XuehaiPan/addlicense
-    rev: '0a8669'
+    rev: "0a8669"
     hooks:
       - id: addlicense
         args: ["-s=only", -l, "MIT", -c, "Lincoln Institute of Land Policy"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,4 +52,4 @@ repos:
     rev: '0a8669'
     hooks:
       - id: addlicense
-        args: [-l, "MIT", -c, "Lincoln Institute of Land Policy"]
+        args: ["-s=only", -l, "MIT", -c, "Lincoln Institute of Land Policy"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,8 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: destroyed-symlinks
       - id: detect-private-key
+      - id: end-of-file-fixer
+        exclude_types: [svg]
       - id: fix-byte-order-marker
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,8 @@ repos:
       # Update the uv lockfile
       - id: uv-lock
       - id: uv-export
+  - repo: https://github.com/XuehaiPan/addlicense
+    rev: '0a8669'
+    hooks:
+      - id: addlicense
+        args: [-l, "MIT", -c, "Lincoln Institute of Land Policy"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,4 +53,5 @@ repos:
     rev: "55a521bf81c24480094950caa3566548fa63875e"
     hooks:
       - id: addlicense
-        args: ["-s=only", -l, "MIT", -c, "Lincoln Institute of Land Policy"]
+        args:
+          ["-s=only", -l, "Apache 2.0", -c, "Lincoln Institute of Land Policy"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,6 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: destroyed-symlinks
       - id: detect-private-key
-      - id: end-of-file-fixer
-        exclude_types: [svg]
       - id: fix-byte-order-marker
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
         exclude_types: [svg]
+        verbose: true
       - id: fix-byte-order-marker
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/Docker/Docker-compose.yaml
+++ b/Docker/Docker-compose.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 name: geoconnex_scheduler
 
 services:

--- a/Docker/dagster/entrypoint.sh
+++ b/Docker/dagster/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 
 # Create an entrypoint for the code server. This could be either dagster dev with debugpy
 # for debugging or just dagster code-server for running in production

--- a/Docker/dagster/workspace.yaml
+++ b/Docker/dagster/workspace.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 # This file specifies how dagster should load user code
 load_from:
   # Each entry here corresponds to a service in the docker-compose file that exposes user code.

--- a/action.yml
+++ b/action.yml
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 name: "Geoconnex Scheduler E2E Test"
 description: "Reusable GitHub Action to run E2E tests for the Dagster build"
 # Allow specifying a custom docker image so we can test specific versions

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Set up Docker
       uses: docker/setup-buildx-action@v2
 
-    - name: Launch Docker Stack
+    - name: Launch Docker Compose
       run: python3 main.py dev --detach
       shell: bash
 

--- a/dagster.yaml
+++ b/dagster.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 scheduler:
   module: dagster.core.scheduler
   class: DagsterDaemonScheduler

--- a/main.py
+++ b/main.py
@@ -20,8 +20,9 @@ def run_subprocess(command: str, returnStdoutAsValue: bool = False, wait: bool =
         stdout=subprocess.PIPE if returnStdoutAsValue else sys.stdout,
         stderr=sys.stderr,
     )
-    stdout, _ = process.communicate()
+    stdout, stderr = process.communicate()
     if process.returncode != 0:
+        print(stderr.decode("utf-8"))
         sys.exit(process.returncode)
     return stdout.decode("utf-8") if returnStdoutAsValue else None
 
@@ -143,4 +144,7 @@ def main():
 
 
 if __name__ == "__main__":
+    assert (
+        os.path.dirname(os.path.abspath(__file__)) == os.getcwd()
+    ), "Please run this script from the root of the repository"
     main()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 import os
 import shutil
 import subprocess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 [project]
 name = "scheduler"
 version = "0.1.0"

--- a/userCode/__init__.py
+++ b/userCode/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+

--- a/userCode/lib/__init__.py
+++ b/userCode/lib/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+

--- a/userCode/lib/classes.py
+++ b/userCode/lib/classes.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 import io
 from pathlib import Path
 import subprocess

--- a/userCode/lib/dagster_helpers.py
+++ b/userCode/lib/dagster_helpers.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 import json
 from dagster import (
     DagsterInstance,

--- a/userCode/lib/env.py
+++ b/userCode/lib/env.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from dagster import get_dagster_logger
 
@@ -96,7 +97,10 @@ LAKEFS_ENDPOINT_URL = strict_env("LAKEFS_ENDPOINT_URL")
 LAKEFS_ACCESS_KEY_ID = strict_env("LAKEFS_ACCESS_KEY_ID")
 LAKEFS_SECRET_ACCESS_KEY = strict_env("LAKEFS_SECRET_ACCESS_KEY")
 
-DAGSTER_YAML_CONFIG = os.path.join(
-    os.path.dirname(__file__), "..", "..", "dagster.yaml"
-)
-assert os.path.exists(DAGSTER_YAML_CONFIG), "the dagster.yaml file does not exist"
+userCodeRoot = Path(__file__).parent.parent.parent.absolute()
+
+DAGSTER_YAML_CONFIG: str = os.path.join(userCodeRoot, "dagster.yaml")
+
+assert Path(
+    DAGSTER_YAML_CONFIG
+).exists(), f"the dagster.yaml file does not exist at {DAGSTER_YAML_CONFIG}"

--- a/userCode/lib/env.py
+++ b/userCode/lib/env.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 import os
 from pathlib import Path
 

--- a/userCode/lib/lakefsUtils.py
+++ b/userCode/lib/lakefsUtils.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 from typing import Optional
 import lakefs
 from lakefs import Client

--- a/userCode/lib/types.py
+++ b/userCode/lib/types.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 from typing import Literal, TypeAlias, TypedDict
 
 

--- a/userCode/lib/utils.py
+++ b/userCode/lib/utils.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 from datetime import datetime
 import os
 import re

--- a/userCode/lib/utils.py
+++ b/userCode/lib/utils.py
@@ -20,6 +20,7 @@ from .dagster_helpers import (
     sources_partitions_def,
 )
 from .classes import S3
+from .types import cli_modes
 from .env import (
     GLEANERIO_DATAGRAPH_ENDPOINT,
     GLEANERIO_PROVGRAPH_ENDPOINT,
@@ -51,7 +52,7 @@ def run_scheduler_docker_image(
     source: str,  # which organization we are crawling
     image_name: str,  # the name of the docker image to pull and validate
     args: list[str],  # the list of arguments to pass to the gleaner/nabu command
-    action_name: str,  # the name of the action to run inside gleaner/nabu
+    action_name: cli_modes,  # the name of the action to run inside gleaner/nabu
     volumeMapping: Optional[list[str]] = None,
 ):
     """Run a docker image inside the dagster docker runtime"""

--- a/userCode/main.py
+++ b/userCode/main.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 import asyncio
 from datetime import datetime
 import os

--- a/userCode/templates/gleanerconfig.yaml.j2
+++ b/userCode/templates/gleanerconfig.yaml.j2
@@ -1,3 +1,8 @@
+{#
+Copyright 2025 Lincoln Institute of Land Policy
+SPDX-License-Identifier: MIT
+#}
+
 # This file represents the prefix for the gleaner config file
 
 ---

--- a/userCode/templates/nabuconfig.yaml.j2
+++ b/userCode/templates/nabuconfig.yaml.j2
@@ -1,3 +1,8 @@
+{#
+Copyright 2025 Lincoln Institute of Land Policy
+SPDX-License-Identifier: MIT
+#}
+
 ---
 minio:
   address: {{ GLEANERIO_MINIO_ADDRESS }}

--- a/userCode/templates/rclone.conf.j2
+++ b/userCode/templates/rclone.conf.j2
@@ -1,3 +1,8 @@
+{#
+Copyright 2025 Lincoln Institute of Land Policy
+SPDX-License-Identifier: MIT
+#}
+
 [lakefs]
 type = s3
 provider = Other

--- a/userCode/test/__init__.py
+++ b/userCode/test/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+

--- a/userCode/test/conftest.py
+++ b/userCode/test/conftest.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 import os
 import pytest
 

--- a/userCode/test/lib.py
+++ b/userCode/test/lib.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 import requests
 
 

--- a/userCode/test/test_e2e.py
+++ b/userCode/test/test_e2e.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 from dagster import (
     DagsterInstance,
     load_assets_from_modules,

--- a/userCode/test/test_unit.py
+++ b/userCode/test/test_unit.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 import os
 from dagster import materialize_to_memory
 import lakefs


### PR DESCRIPTION
- uses https://github.com/google/addlicense with a pre-commit hook
    - the hook is from a fork but uses the same repo. I pinged someone at Google and looks like they might merge that PR hopefully sooner than later
- adds spdx license header which is standardized and machine readable but doesn't require us to paste the entire license