### PR TITLE
General speedups for the pipeline; Fix functionality for export

### DIFF
--- a/Docker/Docker-compose.yaml
+++ b/Docker/Docker-compose.yaml
@@ -16,24 +16,6 @@ services:
     networks:
       - dagster_network
 
-  # Creates buckets for MinIO
-  createbuckets:
-    image: minio/mc
-    depends_on:
-      - minio
-    entrypoint: >
-      /bin/sh -c "
-        sleep 10;
-        /usr/bin/mc alias set myminio http://minio:9000 minio_access_key minio_secret_key;
-        /usr/bin/mc mb myminio/gleanerbucket;
-        /usr/bin/mc anonymous set public myminio/gleanerbucket;
-        sleep infinity;
-      "
-    networks:
-      - dagster_network
-    profiles:
-      - localInfra
-
   # GraphDB service for storage
   graphdb:
     image: khaller/graphdb-free

--- a/userCode/lib/classes.py
+++ b/userCode/lib/classes.py
@@ -38,6 +38,9 @@ class S3:
             secret_key=GLEANER_MINIO_SECRET_KEY,
         )
 
+        if not self.client.bucket_exists(GLEANER_MINIO_BUCKET):
+            self.client.make_bucket(GLEANER_MINIO_BUCKET)
+
     def load(self, data: Any, remote_path: str):
         """Load arbitrary data into s3 bucket"""
         f = io.BytesIO()

--- a/userCode/main.py
+++ b/userCode/main.py
@@ -196,9 +196,9 @@ def gleaner_config(context: AssetExecutionContext):
     sources = []
     names: set[str] = set()
 
-    assert len(Lines) > 0, (
-        f"No sitemaps found in sitemap index {REMOTE_GLEANER_SITEMAP}"
-    )
+    assert (
+        len(Lines) > 0
+    ), f"No sitemaps found in sitemap index {REMOTE_GLEANER_SITEMAP}"
 
     for line in Lines:
         basename = REMOTE_GLEANER_SITEMAP.removesuffix(".xml")

--- a/userCode/templates/nabuconfig.yaml.j2
+++ b/userCode/templates/nabuconfig.yaml.j2
@@ -18,8 +18,8 @@ sparql:
   authenticate: false
   username: ""
   password: ""
-  repository: iow
+  repository: {{ GLEANERIO_DATAGRAPH_ENDPOINT }}
 prefixes:
-     summoned/providera
+    - summoned/providera
     - prov/providera
     - orgs


### PR DESCRIPTION
- the prov graph and data graph are separate and thus don't need to have a dependency in the scheduler pipeline
    - the final export just exports the data graph not the `prov` graph so we don't need to wait on `prov` for exports
- schedule clears the partition status when it is ran, that way the export won't be ran again until everything completes. 
    - fairly sure this gives the behavior we want; namely that graphs are only generated whenever the schedule requests a new crawl; not if we just have a one off asset completion.
- get rid of a compose container to make the buckets and just put this behavior directly in python
- we can download the gleaner and nabu images in parallel with threading 
