### PR TITLE
Enable optimizations for data load

### DIFF
--- a/Docker/Docker-compose.yaml
+++ b/Docker/Docker-compose.yaml
@@ -28,8 +28,8 @@ services:
     ports:
       - "7200:7200"
     environment:
-      - JAVA_XMX=4g
-      - JAVA_XMS=2048m
+      - JAVA_XMX=8g
+      - JAVA_XMS=4g
     networks:
       - dagster_network
     volumes:

--- a/Docker/graphdb/iow-config.ttl
+++ b/Docker/graphdb/iow-config.ttl
@@ -19,7 +19,7 @@
 
             # Inference and Validation
             graphdb:ruleset "rdfsplus-optimized" ;
-            graphdb:disable-sameAs "true" ;
+            graphdb:disable-sameAs "false" ;
             graphdb:check-for-inconsistencies "false" ;
 
             # Indexing

--- a/Docker/graphdb/iow-config.ttl
+++ b/Docker/graphdb/iow-config.ttl
@@ -25,7 +25,7 @@
             # Indexing
             graphdb:entity-id-size "32" ;
             graphdb:enable-context-index "false" ;
-            graphdb:enablePredicateList "true" ;
+            graphdb:enablePredicateList "false" ;
             graphdb:enable-fts-index "false" ;
             graphdb:fts-indexes ("default" "iri") ;
             graphdb:fts-string-literals-index "default" ;
@@ -43,7 +43,7 @@
             graphdb:repository-type "file-repository" ;
             graphdb:storage-folder "storage" ;
             graphdb:entity-index-size "10000000" ;
-            graphdb:in-memory-literal-properties "true" ;
+            graphdb:in-memory-literal-properties "false" ;
             graphdb:enable-literal-index "true" ;
         ]
     ].

--- a/Docker/graphdb/iowprov-config.ttl
+++ b/Docker/graphdb/iowprov-config.ttl
@@ -43,7 +43,7 @@
             graphdb:repository-type "file-repository" ;
             graphdb:storage-folder "storage" ;
             graphdb:entity-index-size "10000000" ;
-            graphdb:in-memory-literal-properties "true" ;
-            graphdb:enable-literal-index "false" ;
+            graphdb:in-memory-literal-properties "false" ;
+            graphdb:enable-literal-index "true" ;
         ]
     ].

--- a/Docker/graphdb/iowprov-config.ttl
+++ b/Docker/graphdb/iowprov-config.ttl
@@ -25,7 +25,7 @@
             # Indexing
             graphdb:entity-id-size "32" ;
             graphdb:enable-context-index "false" ;
-            graphdb:enablePredicateList "true" ;
+            graphdb:enablePredicateList "false" ;
             graphdb:enable-fts-index "false" ;
             graphdb:fts-indexes ("default" "iri") ;
             graphdb:fts-string-literals-index "default" ;
@@ -44,6 +44,6 @@
             graphdb:storage-folder "storage" ;
             graphdb:entity-index-size "10000000" ;
             graphdb:in-memory-literal-properties "true" ;
-            graphdb:enable-literal-index "true" ;
+            graphdb:enable-literal-index "false" ;
         ]
     ].

--- a/Docker/graphdb/iowprov-config.ttl
+++ b/Docker/graphdb/iowprov-config.ttl
@@ -19,7 +19,7 @@
 
             # Inference and Validation
             graphdb:ruleset "rdfsplus-optimized" ;
-            graphdb:disable-sameAs "true" ;
+            graphdb:disable-sameAs "false" ;
             graphdb:check-for-inconsistencies "false" ;
 
             # Indexing

--- a/dagster.yaml
+++ b/dagster.yaml
@@ -13,8 +13,8 @@ run_monitoring:
   # values below are the defaults, and don't need to be specified except to override them
   # start_timeout_seconds: 180
   # cancel_timeout_seconds: 180
-  # Reasonable approximation for the max amount of time it would take to crawl a sitemap of the max possible size (1 day)
-  max_runtime_seconds: 86400
+  # Reasonable approximation for the max amount of time it would take to crawl a sitemap of the max possible size (2 days)
+  max_runtime_seconds: 172800
   # max_resume_run_attempts: 3 # experimental if above 0
 
   # NOTE: Timeouts can be confusing given the fact that polling only occurs


### PR DESCRIPTION
- Enable owl:sameAs
- Double job timeout
- tune graphDb options for data loading