### PR TITLE
Clean up orgs and general sync to reduce duplication

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,6 +21,7 @@ def clear_graph():
 
 
 def insert_triples_as_graph(graph_name: str, triples: str):
+    """Insert a named graph into the triplestore. Useful for testing"""
     sparql_update = f"""
         INSERT DATA {{
             GRAPH <{graph_name}> {{

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,6 +20,24 @@ def clear_graph():
     assert response.ok, response.text
 
 
+def insert_triples_as_graph(graph_name: str, triples: str):
+    sparql_update = f"""
+        INSERT DATA {{
+            GRAPH <{graph_name}> {{
+                {triples}
+            }}
+        }}
+        """
+    # we have to post against the statements url with the proper header
+    # since it is an update and not a general stateless query
+    response = requests.post(
+        "http://localhost:7200/repositories/iow/statements",
+        data=sparql_update,
+        headers={"Content-Type": "application/sparql-update"},
+    )
+    assert response.ok, response.text
+
+
 def execute_sparql(query: str) -> dict[str, list[str]]:
     """Run a sparql query on graphdb and return the results"""
     endpoint = "http://localhost:7200/repositories/iow"

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -131,7 +131,9 @@ def test_e2e():
     # make sure we have 2 orgs graphs since we crawled 2 sources so far
     # urn:iow:orgs is nabu's way of serializing the s3 prefix 'orgs/'
     assert sum("urn:iow:orgs" in g for g in all_graphs["g"]) == 2
-    assert sum("DUMMY_PREFIX_TO_DROP" in g for g in all_graphs["g"]) == 0
+    assert not any("DUMMY_PREFIX_TO_DROP" in g for g in all_graphs["g"]), (
+        "The dummy graph we inserted crawling was not dropped correctly"
+    )
 
 
 def test_dynamic_partitions():

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -131,9 +131,9 @@ def test_e2e():
     # make sure we have 2 orgs graphs since we crawled 2 sources so far
     # urn:iow:orgs is nabu's way of serializing the s3 prefix 'orgs/'
     assert sum("urn:iow:orgs" in g for g in all_graphs["g"]) == 2
-    assert not any("DUMMY_PREFIX_TO_DROP" in g for g in all_graphs["g"]), (
-        "The dummy graph we inserted crawling was not dropped correctly"
-    )
+    assert not any(
+        "DUMMY_PREFIX_TO_DROP" in g for g in all_graphs["g"]
+    ), "The dummy graph we inserted crawling was not dropped correctly"
 
 
 def test_dynamic_partitions():

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -15,7 +15,7 @@ from userCode.pipeline import sources_partitions_def
 
 from dagster import AssetsDefinition, AssetSpec, SourceAsset
 
-from .helpers import execute_sparql, clear_graph
+from .helpers import execute_sparql, clear_graph, insert_triples_as_graph
 
 
 def assert_data_is_linked_in_graph():
@@ -38,9 +38,9 @@ def assert_data_is_linked_in_graph():
     """
     resultDict = execute_sparql(query)
     # make sure that the florida canal monitoring location is on the florida river mainstem
-    assert (
-        len(resultDict["monitoringLocation"]) > 0
-    ), "There were no linked monitoring locations for the Florida River Mainstem"
+    assert len(resultDict["monitoringLocation"]) > 0, (
+        "There were no linked monitoring locations for the Florida River Mainstem"
+    )
     assert (
         "https://geoconnex.us/cdss/gages/FLOCANCO" in resultDict["monitoringLocation"]
     )
@@ -55,6 +55,14 @@ def assert_rclone_is_installed_properly():
 def test_e2e():
     """Run the e2e test on the entire geoconnex graph"""
     clear_graph()
+    # insert a dummy graph before running that should be dropped after syncing ref_mainstems_mainstems__0
+    insert_triples_as_graph(
+        "urn:iow:summoned:ref_mainstems_mainstems__0:DUMMY_PREFIX_TO_DROP",
+        """
+        <http://example.org/resource/1> <http://example.org/property/name> "Alice" .
+        <http://example.org/resource/2> <http://example.org/property/name> "Bob" .
+        """,
+    )
 
     instance = DagsterInstance.ephemeral()
     assets = load_assets_from_modules([pipeline])
@@ -66,12 +74,12 @@ def test_e2e():
         if isinstance(asset, (AssetsDefinition, AssetSpec, SourceAsset))
     ]
     # These three assets are needed to generate the dynamic partition.
-    result = materialize(
+    all_graphs = materialize(
         assets=filtered_assets,
         selection=["nabu_config", "gleaner_config", "docker_client_environment"],
         instance=instance,
     )
-    assert result.success
+    assert all_graphs.success
 
     resolved_job = definitions.get_job_def("harvest_source")
 
@@ -80,27 +88,27 @@ def test_e2e():
     )
     assert len(all_partitions) > 0, "Partitions were not generated"
 
-    result = resolved_job.execute_in_process(
+    all_graphs = resolved_job.execute_in_process(
         instance=instance, partition_key="ref_mainstems_mainstems__0"
     )
 
-    assert result.success, "Job execution failed for partition 'mainstems__0'"
+    assert all_graphs.success, "Job execution failed for partition 'mainstems__0'"
 
-    query = """
+    objects_query = """
     select * where {
         <https://geoconnex.us/ref/mainstems/42750> <https://schema.org/name> ?o .
     } limit 100
     """
 
-    resultDict = execute_sparql(query)
-    assert (
-        "Florida River" in resultDict["o"]
-    ), "The Florida River Mainstem was not found in the graph"
+    resultDict = execute_sparql(objects_query)
+    assert "Florida River" in resultDict["o"], (
+        "The Florida River Mainstem was not found in the graph"
+    )
 
-    result = resolved_job.execute_in_process(
+    all_graphs = resolved_job.execute_in_process(
         instance=instance, partition_key="cdss_co_gages__0"
     )
-    assert result.success, "Job execution failed for partition 'cdss_co_gages__0'"
+    assert all_graphs.success, "Job execution failed for partition 'cdss_co_gages__0'"
 
     assert_data_is_linked_in_graph()
     # Don't want to actually transfer the file but should check it is installed
@@ -111,6 +119,19 @@ def test_e2e():
         .execute_in_process(instance=instance)
         .success
     )
+
+    all_graphs = execute_sparql("""
+    SELECT DISTINCT ?g 
+    WHERE { 
+        GRAPH ?g { 
+            ?s ?p ?o .
+        } 
+    }
+    """)
+    # make sure we have 2 orgs graphs since we crawled 2 sources so far
+    # urn:iow:orgs is nabu's way of serializing the s3 prefix 'orgs/'
+    assert sum("urn:iow:orgs" in g for g in all_graphs["g"]) == 2
+    assert sum("DUMMY_PREFIX_TO_DROP" in g for g in all_graphs["g"]) == 0
 
 
 def test_dynamic_partitions():


### PR DESCRIPTION
- Address https://github.com/internetofwater/nabu/issues/45 and make each partition only operate upon its own org
- Add a test for org releasing to make sure there are as many orgs as we expect
- Get rid of `release` and `object` for the main summoned data in the datagraph and just use `sync`. 
    - I presume that in the past `release` and `object` may have been used since `sync` was called `prune` and thus only get rid of unnecessary objects. But now since it does both i think sync is just better for our pipeline.
    - `release` and `object` is probably faster than `sync` if just done on its own but i believe we need to call `sync` anyways so it seems like it is best to just use `sync`