### PR TITLE
setting to raise or ignore error on exit 3

### DIFF
--- a/userCode/lib/containers.py
+++ b/userCode/lib/containers.py
@@ -43,6 +43,9 @@ class SitemapHarvestConfig(Config):
     validate_shacl: bool = False
     useSSL: bool = S3_USE_SSL
 
+    # whether or not to raise an exception upon encountering a 3 exit code
+    exit_3_is_fatal: bool = False
+
 
 class SitemapHarvestContainer:
     """A container for running web crawl operations"""
@@ -80,6 +83,7 @@ class SitemapHarvestContainer:
             NABU_IMAGE,
             argsAsStr,
             "sitemap_harvest",
+            exit_3_is_fatal=config.exit_3_is_fatal,
             volumeMapping=["/tmp/geoconnex/sitemap.xml:/app/sitemap.xml"],
         )
 

--- a/userCode/main.py
+++ b/userCode/main.py
@@ -34,6 +34,7 @@ for starting, monitoring, or initializing the
 pipeline for Geoconnex. 
 """
 
+
 harvest_job = define_asset_job(
     "harvest_source",
     description="harvest a source for the geoconnex graphdb",

--- a/userCode/main_test.py
+++ b/userCode/main_test.py
@@ -15,6 +15,7 @@ from userCode import pipeline
 import userCode.main as main
 from userCode.main import definitions
 from userCode.pipeline import (
+    EXIT_3_IS_FATAL,
     sources_partitions_def,
 )
 
@@ -85,7 +86,9 @@ def test_e2e():
     harvest_job = definitions.get_job_def("harvest_source")
 
     assert harvest_job.execute_in_process(
-        instance=instance, partition_key="ref_mainstems_mainstems__0"
+        instance=instance,
+        tags={EXIT_3_IS_FATAL: str(True)},
+        partition_key="ref_mainstems_mainstems__0",
     ).success, "Job execution failed for partition 'mainstems__0'"
 
     objects_query = """


### PR DESCRIPTION
- add a config option to raise or ignore exit status 3; exit status 3 in `nabu harvest` signifies there were errors crawling individual sites in the sitemap but nothing fatal that would crash the run