### PR TITLE
Fix gh actions branch

### DIFF
--- a/userCode/main_test.py
+++ b/userCode/main_test.py
@@ -76,7 +76,7 @@ def test_e2e():
         selection=["sitemap_partitions", "docker_client_environment"],
         instance=instance,
     )
-    assert not all_graphs.success
+    assert all_graphs.success
 
     all_partitions = sources_partitions_def.get_partition_keys(
         dynamic_partitions_store=instance


### PR DESCRIPTION
Seems like there was an issue with the github action. If you specify the repository in the composite action it won't check out the PR branch. By getting rid of the explicit repository specifier, it implicitly checks out whatever ref made the event which is what we want to allow both main from other repos or a PR branch inside this one.