### PR TITLE
Fix flakey test for florida river

### DIFF
--- a/userCode/defs_test.py
+++ b/userCode/defs_test.py
@@ -22,13 +22,17 @@ import userCode.defs as defs
 def assert_data_is_linked_in_graph():
     """Check that a mainstem is associated with a monitoring location in the graph"""
     query = """
-    select * where {
-        <https://geoconnex.us/cdss/gages/FARMERCO> <https://schema.org/name> ?o .
-    } limit 100
+    PREFIX schema: <https://schema.org/>
+
+    SELECT * WHERE {
+     ?subject schema:name "FLORIDA FARMERS CANAL" .
+    } LIMIT 100
     """
 
     resultDict = SparqlClient().execute_sparql(query)
-    assert "FLORIDA FARMERS CANAL" in resultDict["o"]
+    assert len(resultDict["subject"]) >= 1, (
+        "Could not find the Florida Canal in the graph"
+    )
 
     query = """
     PREFIX hyf: <https://www.opengis.net/def/schema/hy_features/hyf/>
@@ -43,7 +47,8 @@ def assert_data_is_linked_in_graph():
         "There were no linked monitoring locations for the Florida River Mainstem"
     )
     assert (
-        "https://geoconnex.us/cdss/gages/FLOCANCO" in resultDict["monitoringLocation"]
+        "https://pids.geoconnex.dev/cdss/gages/FLOCANCO"
+        in resultDict["monitoringLocation"]
     )
 
 
@@ -92,7 +97,7 @@ def test_e2e():
 
     objects_query = """
     select * where {
-        <https://geoconnex.us/ref/mainstems/42750> <https://schema.org/name> ?o .
+        <https://pids.geoconnex.dev/ref/mainstems/42750> <https://schema.org/name> ?o .
     } limit 100
     """
 


### PR DESCRIPTION
Fixes the test which was previously failing, saying that the Florida River wasn't in the test graph.

It appears the URIs were changed and as a result, the geoconnex.us ones got switched to `pids.geoconnex.dev `

@webb-ben could you confirm if this fix to the test seems reasonable? My one apprehension is that it seems like we have some URIs that are pids.geoconnex.dev but some there are left over for the linked mainstems which are `geoconnex.us`. I am not sure if we want to have all the URIs use the same basename; happy to defer to whatever you think is best.

i.e. this query still works since it appears the jsonld properties don't refer to `pids.geoconnex.us` but rather the prod ones.

```sparql
    PREFIX hyf: <https://www.opengis.net/def/schema/hy_features/hyf/>

    select * where { 
        ?monitoringLocation hyf:referencedPosition/hyf:HY_IndirectPosition/hyf:linearElement <https://geoconnex.us/ref/mainstems/42750> .
    } limit 100 
```