### PR TITLE
Don't auto merge renci push

### DIFF
--- a/userCode/assetGroups/export.py
+++ b/userCode/assetGroups/export.py
@@ -117,7 +117,6 @@ def stream_nquad_file_to_renci(
         path_to_file=export_graphdb_as_nquads,
         lakefs_client=lakefs_client,
     )
-    lakefs_client.merge_branch_into_main(branch="develop")
 
 
 @asset(
@@ -144,7 +143,17 @@ def stream_all_release_graphs_to_renci(
         path_to_file=RELEASE_GRAPH_LOCATION_IN_S3,
         lakefs_client=lakefs_client,
     )
-    lakefs_client.merge_branch_into_main(branch="develop")
+
+
+@asset(group_name=EXPORT_GROUP)
+def merge_lakefs_branch_into_main():
+    """
+    Manually merge the develop branch into the main branch
+    the renci lakefs. This is done as a separate step to avoid
+    auto merging unfinished or incorrect assets until they have been
+    checked
+    """
+    LakeFSClient("geoconnex").merge_branch_into_main(branch="develop")
 
 
 @asset(group_name=EXPORT_GROUP)


### PR DESCRIPTION
Change to not auto merge the lakefs assets; this is since we are still working on the rclone logic and it is generally a good practice to check and make sure the asset pushed to renci was valid before we merge it into the main lakefs branch, signifying that it should be ingested by the RENCI folks