### PR TITLE
Increase max concurrent runs

### DIFF
--- a/dagster.yaml
+++ b/dagster.yaml
@@ -6,7 +6,7 @@ scheduler:
   class: DagsterDaemonScheduler
 
 run_queue:
-  max_concurrent_runs: 4
+  max_concurrent_runs: 7
 
 run_monitoring:
   enabled: true


### PR DESCRIPTION
Increase the max concurrent runs. 4 is a bit low and slows things down. It is reasonable to be harvesting more than 4 as long as we are harvesting from different servers, i.e. USGS, 2 sites from reference features, wqp, wwdh, and iow links could be harvested at once. In general it is best practice to not queue up too much all at once and 4 is still reasonable, but i think increasing it a bit higher gives from more flexibility when testing. Also for other jobs like those for creating the nquads, these can use much more than 4.