### PR TITLE
Allow for env override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ code_location_target_module = "userCode.defs"
 
 [tool.pytest.ini_options]
 # we want to be able to override values in the .env file
-# in order to test with custom 
+# in order to test with custom environment variables
+# without changing the base config
 env_override_existing_values = 0
 env_files = [
     ".env"


### PR DESCRIPTION
Allow overriding the .env file. This is needed for us to use custom nabu images in CI/CD. Otherwise pytest will always use nabu:latest since it is specified in the .env