### PR TITLE
Make sure release asset is named properly, not "prov-release"

### DIFF
--- a/userCode/assetGroups/release_graph_generator.py
+++ b/userCode/assetGroups/release_graph_generator.py
@@ -29,7 +29,7 @@ def release_graphs_for_all_summoned_jsonld(
     context: AssetExecutionContext, config: SynchronizerConfig
 ):
     """Construct an nq file from all the jsonld for a single sitemap"""
-    SynchronizerContainer("prov-release", context.partition_key).run(
+    SynchronizerContainer("release", context.partition_key).run(
         f"release --compress --prefix summoned/{context.partition_key}", config
     )
 


### PR DESCRIPTION
The asset for creating release graphs from JSON-LD info should be named just "release" and not "prov-release" since it does not yet deal with prov info. This was a typo