### PR TITLE
Improve Concurrency

### DIFF
--- a/dagster.yaml
+++ b/dagster.yaml
@@ -5,14 +5,15 @@ scheduler:
   module: dagster.core.scheduler
   class: DagsterDaemonScheduler
 
-run_queue:
-  # In order to set and forget the crawler
-  # we limit this to 1 since some sitemaps at
-  # external organizations will give undefined errors
-  # when you crawl them with too many workers.
-  # In the future this can be bumped back up
-  # once this is added: https://github.com/internetofwater/scheduler/issues/184
-  max_concurrent_runs: 1
+concurrency:
+  runs:
+    max_concurrent_runs: 6
+  pools:
+    # dagster has no way to declaratively set the limit for a specific
+    # pool; but since we have only one pool, we can set it here as the default
+    # see https://github.com/dagster-io/dagster/issues/19793
+    # this is done to address https://github.com/internetofwater/scheduler/issues/184
+    default_limit: 1
 
 run_monitoring:
   enabled: true

--- a/userCode/assetGroups/harvest.py
+++ b/userCode/assetGroups/harvest.py
@@ -31,6 +31,7 @@ EXIT_3_IS_FATAL = "exit_3_is_fatal"
     partitions_def=sources_partitions_def,
     deps=[docker_client_environment, sitemap_partitions],
     group_name=HARVEST_GROUP,
+    pool="harvest_pool",
 )
 def harvest_sitemap(
     context: AssetExecutionContext,


### PR DESCRIPTION
We can separate the concurrency limit for the harvest operation from the global concurrency limit in the scheduler. This allows us to limit the operations out of our control more strictly but permit others to have more runs.

Added a comment on the caveats.

Note that the harvest concurrency limit is still across all partitions in that asset due to #184 