### PR TITLE
Ensure shacl service restarts by default

### DIFF
--- a/Docker/Docker-compose.yaml
+++ b/Docker/Docker-compose.yaml
@@ -14,6 +14,7 @@ services:
     profiles:
       - localInfra
       - production
+    restart: always
 
   # MinIO service for storage
   minio:


### PR DESCRIPTION
the shacl service should always restart on failure to ensure the crawl can always use it, even if there is an edge case and it crashed previously