### PR TITLE
Bump qlever version

### DIFF
--- a/assets/Qleverfile
+++ b/assets/Qleverfile
@@ -29,7 +29,7 @@ ACCESS_TOKEN = ChangeMe
 [runtime]
 SYSTEM = docker
 # pin to a specific image
-IMAGE  = docker.io/adfreiburg/qlever:commit-93ec01a
+IMAGE  = docker.io/adfreiburg/qlever:pr-2822
 
 [ui]
 UI_PORT   = 8176

--- a/requirements.txt
+++ b/requirements.txt
@@ -1928,8 +1928,9 @@ pyyaml==6.0.2 \
     #   lakefs
     #   qlever
     #   uvicorn
-qlever==0.5.23 \
-    --hash=sha256:cf0b0d60e4ee71dd9133d3518acd6d89eadb3c9fc1a18c672605b7c109e6c012
+qlever==0.5.46 \
+    --hash=sha256:3bd78afbde2ecc552c5a83cf7d39e92580c91b98c69c670198c935cc9b3450a3 \
+    --hash=sha256:3ff7917da0f4f3c36b15552cf82aaeadb317d142743380e38e31d3e2c32f7233
     # via scheduler
 questionary==2.1.0 \
     --hash=sha256:44174d237b68bc828e4878c763a9ad6790ee61990e0ae72927694ead57bab8ec \
@@ -1938,6 +1939,7 @@ questionary==2.1.0 \
 rdflib==7.5.0 \
     --hash=sha256:663083443908b1830e567350d72e74d9948b310f827966358d76eebdc92bf592 \
     --hash=sha256:b011dfc40d0fc8a44252e906dcd8fc806a7859bc231be190c37e9568a31ac572
+    # via qlever
 referencing==0.36.2 \
     --hash=sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa \
     --hash=sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0
@@ -1954,8 +1956,13 @@ requests==2.32.3 \
     #   docker
     #   github3-py
     #   gql
+    #   requests-sse
     #   requests-toolbelt
     #   scheduler
+requests-sse==0.5.3 \
+    --hash=sha256:107c63afb2a2292b422ab2504849f3adb54b4c884700646ebe9f6e4178ba375c \
+    --hash=sha256:dc3e053e22fdcf002ca1fbd1794967d42b82b24539f5b7fe0e807301dd4ef4ec
+    # via qlever
 requests-toolbelt==1.0.0 \
     --hash=sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6 \
     --hash=sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06
@@ -2313,7 +2320,9 @@ toposort==1.10 \
 tqdm==4.67.1 \
     --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2 \
     --hash=sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2
-    # via dagster
+    # via
+    #   dagster
+    #   qlever
 typer==0.15.1 \
     --hash=sha256:7994fb7b8155b64d3402518560648446072864beefd44aa2dc36972a5972e847 \
     --hash=sha256:a0588c0a7fa68a1978a069818657778f86abe6ff5ea6abf472f940a08bfe4f0a

--- a/userCode/assetGroups/export.py
+++ b/userCode/assetGroups/export.py
@@ -94,7 +94,17 @@ def stream_qlever_index_to_gcs(context: AssetExecutionContext):
     if RUNNING_AS_TEST_OR_DEV():
         get_dagster_logger().warning("Skipping export as we are running in test mode")
         return
+
     s3 = S3()
+    existing_objects = s3.client.list_objects(
+        prefix="geoconnex_index/", bucket_name=s3.bucket, recursive=True
+    )
+    get_dagster_logger().info("Deleting existing old index files in geoconnex_index/")
+    for obj in existing_objects:
+        get_dagster_logger().info(f"Deleting {obj}")
+        assert obj.object_name, f"obj name should not be empty but got '{obj}'"
+        s3.client.remove_object(object_name=obj.object_name, bucket_name=s3.bucket)
+    get_dagster_logger().info("Finished deleting old index files")
     for file in GEOCONNEX_INDEX_DIRECTORY.iterdir():
         if not file.is_file():
             raise Exception(f"{file} is not a file and thus cannot be uploaded")

--- a/uv.lock
+++ b/uv.lock
@@ -2779,16 +2779,20 @@ wheels = [
 
 [[package]]
 name = "qlever"
-version = "0.5.23"
+version = "0.5.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
     { name = "psutil" },
     { name = "pyyaml" },
+    { name = "rdflib" },
+    { name = "requests-sse" },
     { name = "termcolor" },
+    { name = "tqdm" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8e/4c2688b7a54592acf5e7be2cc0e334fe73cf503ce78b8f41f8e7a1856b23/qlever-0.5.46.tar.gz", hash = "sha256:3ff7917da0f4f3c36b15552cf82aaeadb317d142743380e38e31d3e2c32f7233", size = 89428, upload-time = "2026-04-16T10:09:07.642Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/d9/d340a263e070f5db90f3513adef43ff83f9be25483df844a6d6f931d85d7/qlever-0.5.23-py3-none-any.whl", hash = "sha256:cf0b0d60e4ee71dd9133d3518acd6d89eadb3c9fc1a18c672605b7c109e6c012", size = 82621, upload-time = "2025-05-04T00:19:35.237Z" },
+    { url = "https://files.pythonhosted.org/packages/30/75/87c65e0c02bea531aa4d46fe6207c442552c17065698ac023d0ee0902c0d/qlever-0.5.46-py3-none-any.whl", hash = "sha256:3bd78afbde2ecc552c5a83cf7d39e92580c91b98c69c670198c935cc9b3450a3", size = 120368, upload-time = "2026-04-16T10:09:06.018Z" },
 ]
 
 [[package]]
@@ -2843,6 +2847,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
+]
+
+[[package]]
+name = "requests-sse"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/94/f0f29584c3ca24c29a72e19a28136f73ed08adddc93fb8a0c998577c9085/requests_sse-0.5.3.tar.gz", hash = "sha256:107c63afb2a2292b422ab2504849f3adb54b4c884700646ebe9f6e4178ba375c", size = 9057, upload-time = "2026-03-11T15:35:49.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/3704da8cc1cb91cc0ccee8fb03d8ed11217afcd028352f3b1242fee2f4f1/requests_sse-0.5.3-py3-none-any.whl", hash = "sha256:dc3e053e22fdcf002ca1fbd1794967d42b82b24539f5b7fe0e807301dd4ef4ec", size = 10198, upload-time = "2026-03-11T15:35:47.872Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We will need to see if this changes the build at all. Hard to test without deploying and just running it on real data.

At least for the time being, I don't think there is anything that we need to change beyond the image tag. Qlever doesn't really have semantic versioning (?)  https://github.com/ad-freiburg/qlever/issues/2011 so it is a bit hard to know for certain if we should expect breaking changes.

As another thing, we could investigate installing qlever directly on from debian instead of pypi. That guarantees the binary version of qlever and the cli to control it are linked to the proper version together. Also apparently in the qlever wiki it says that docker adds a bit of overhead