### PR TITLE
Push user code image to ghcr

### DIFF
--- a/.github/workflows/push_to_ghcr.yml
+++ b/.github/workflows/push_to_ghcr.yml
@@ -1,0 +1,42 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: Apache-2.0
+
+name: Push To Images to GHCR
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{
+    github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_push:
+    name: "build and push user code image"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and export
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Docker/dagster/Dockerfile_user_code
+          push: true
+          tags: ghcr.io/internetofwater/geoconnex_dagster_user_code:latest
+          cache-from: type=gha,scope=geoconnex_dagster_user_code
+          platforms: linux/amd64
+          cache-to: type=gha,mode=max,scope=geoconnex_dagster_user_code


### PR DESCRIPTION
Slowly but surely my goal is to produce the user code image in github and then have it so the VM and just pull the image on deploy, both speeding it up, allowing us to cache stuff better, and iterate easier when making changes to Python without needing to redeploy the terraform