### PR TITLE
Tag Geoconnex Graph

### DIFF
--- a/userCode/assetGroups/index_generator.py
+++ b/userCode/assetGroups/index_generator.py
@@ -207,7 +207,7 @@ def oci_artifact():
             relative_path = file.relative_to(GEOCONNEX_GRAPH_DIRECTORY)
             files_to_upload.append(f"{relative_path}:application/n-quads")
 
-    command = f"oras push {registry}/internetofwater/geoconnex-graph:{tags} {' '.join(files_to_upload)} --username internetofwater --password-stdin"
+    command = f"oras push {registry}/internetofwater/geoconnex-graph:{tags} {' '.join(files_to_upload)} --username internetofwater --password-stdin --annotation 'org.opencontainers.image.description=All RDF data in NQuad format which makes up the Geoconnex Graph as of the date in the image tag' --annotation 'org.opencontainers.image.source=https://github.com/internetofwater/geoconnex.us'"
 
     logger = get_dagster_logger()
     logger.info(f"Running '{command}'")


### PR DESCRIPTION
In order to tag the OCI image upload and associate it with a repo on Github, you need to add the respective annotation metadata to the oras push command.

https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

I am associating the output package with the main geoconnex.us repo. I can change that to be associated with scheduler if you think that is better but I think that in general the main geoconnex.us repository is it bit more semantic.

That being said I will need to check if there are any limitations on our personal access token that would prevent this. I can't seem to determine if it is scoped to the repo or the org 

I am pretty sure 