### PR TITLE
Allow using prebuilt images in cloud production environment

### DIFF
--- a/Docker/Docker-compose.yaml
+++ b/Docker/Docker-compose.yaml
@@ -58,6 +58,7 @@ services:
   # Dagster Webserver
   dagster_webserver:
     container_name: dagster_webserver
+    image: ${DAGSTER_SERVER_IMAGE:-geoconnex_dagster_server:local}
     build:
       context: ..
       dockerfile: ./Docker/dagster/Dockerfile_dagster
@@ -87,6 +88,7 @@ services:
   # Dagster Daemon
   dagster_daemon:
     container_name: dagster_daemon
+    image: ${DAGSTER_SERVER_IMAGE:-geoconnex_dagster_server:local}
     build:
       context: ..
       dockerfile: ./Docker/dagster/Dockerfile_dagster
@@ -95,7 +97,7 @@ services:
       - dagster-daemon
       - run
     volumes:
-      # we mount the docker sock to allow us to spawn nabu / gleaner containers
+      # we mount the docker sock to allow us to spawn nabu containers
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/io_manager_storage:/tmp/io_manager_storage
     depends_on:
@@ -111,6 +113,7 @@ services:
   # Dagster User Code
   dagster_user_code:
     container_name: dagster_user_code
+    image: ${DAGSTER_USER_CODE_IMAGE:-geoconnex_dagster_user_code:local}
     build:
       context: ..
       dockerfile: ./Docker/dagster/Dockerfile_user_code
@@ -118,7 +121,7 @@ services:
     networks:
       - dagster_network
     environment:
-      - DAGSTER_CURRENT_IMAGE=dagster_user_code_image
+      - DAGSTER_CURRENT_IMAGE=${DAGSTER_USER_CODE_IMAGE:-geoconnex_dagster_user_code:local}
       - NABU_IMAGE=${NABU_IMAGE:-internetofwater/nabu:latest}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -146,19 +149,6 @@ services:
     restart: unless-stopped
     networks:
       - dagster_network
-
-  # # Headless browser (currently commented out since not needed)
-  # scheduler_headless:
-  #   image: chromedp/headless-shell:latest
-  #   container_name: scheduler_headless
-  #   ports:
-  #     - "9222:9222"
-  #   networks:
-  #     - dagster_network
-  #   environment:
-  #     - SERVICE_PORTS=9222
-  #   profiles:
-  #     - production
 
 volumes:
   scheduler_minio_data:

--- a/makefile
+++ b/makefile
@@ -50,6 +50,8 @@ prodBuild: init-env
 
 # Run dagster with dockerized Python code but don't run any storage locally
 cloudProd: init-env
+	DAGSTER_USER_CODE_IMAGE=ghcr.io/internetofwater/geoconnex_dagster_user_code:latest \
+	DAGSTER_SERVER_IMAGE=ghcr.io/internetofwater/geoconnex_dagster_server:latest \
 	$(PRODUCTION_USING_CLOUD_INFRA) up -d $(ARGS)
 
 # Stop all docker services
@@ -60,7 +62,6 @@ down:
 pull:
 	$(ALL_SERVICES) pull
 	docker pull internetofwater/nabu:latest
-	docker pull internetofwater/gleaner:latest
 
 # Copy .env.example to .env only if .env does not exist
 init-env:


### PR DESCRIPTION
Currently the terraform for `harvest.geoconnex.us` runs `cloudProd` which until now, requires building all the services on every deploy. This slows down iterating on things. It also makes it hard to pull in new updates since you have to bring the compose project down, run git pull, figure out the new permissions on the files, build, then bring it back up. 

 It is better to prebuild the images in CI and then directly source them in production. This makes it much easier to iterate on new changes. 

If the environment variable is not set, we fall back to the local build so this should not affect local dev.