### PR TITLE
Escape slack error message

### DIFF
--- a/userCode/lib/dagster.py
+++ b/userCode/lib/dagster.py
@@ -90,6 +90,6 @@ def slack_error_fn(context: RunFailureSensorContext) -> str:
     # id and name so you can just send the error. We don't need other data in the string
     source_being_crawled = context.partition_key
     if source_being_crawled:
-        return f"Error in Geoconnex pipeline for partition: {source_being_crawled}: {context.failure_event.message}"
+        return f"Error in Geoconnex pipeline for partition: `{source_being_crawled}`: `{context.failure_event.message}`"
     else:
-        return f"Error in Geoconnex pipeline: {context.failure_event.message}"
+        return f"Error in Geoconnex pipeline: `{context.failure_event.message}`"


### PR DESCRIPTION
Escape the slack error message, otherwise the `:` in the partition names can sometimes end up getting rendered as an emoji or obscuring the text on some slack clients. Seeing this primary on mobile